### PR TITLE
Adapt for new code structure into a single repository

### DIFF
--- a/architecture/code.md
+++ b/architecture/code.md
@@ -23,52 +23,91 @@ Caliopen code must respect at least a 3 layers model:
 This layer structure impact on packaging logic to respect split of protocol layer and others, named
 base layers. Same data may be managed thru many protocols.
 
-## Packaging
 
-To ensure covering many protocols for many kind of data (contact, message, calendar, file, ...),
-Caliopen is decoupled in many python packages. Aim is mainly to limit dependencies for a component
-in platform deployment logic, this way a LMTP server will not have pyramid as dependency for example.
+# Repositories architecture
+Below is our target repository structure.  
+For now, all directories are not created, as some Caliopen's components are still missing or are not yet implemented.
 
-There is 2 main type of package:
+### top level 
+```
+├── doc     : (work in progress) all documentation for developers, administrators and users
+├── infra   : (to be done) tools to manage and supervise Caliopen platform
+├── src     : all source code goes here
+└── devtools: scripts, fixtures and other tools to build development environment
+```
 
-* base, are defined in this kind of package:
-  * storage models classes
-  * core classes to manage models
-  * input parameters classes
-  * return parameters classes
+### the `src` directory
+Source code for Caliopen platform and clients applications.  
+**NB**: Caliopen is not bind to a specific language : one may finds softwares components written in python, Go, C, java… 
 
-* protocol oriented, where protocol logic act, sometimes only a part of it (API splitted by )
+Caliopen is made of :
 
-### Base packages
+ * the *frontends* => applications that run on clients' devices : browsers, computers, smartphones…
+ * the *backend* => the Caliopen platform that runs on servers.   
+ 
+Here is our target architecture for `src` :
+ 
+```
+├── backend
+│   ├── agents
+│   ├── brokers
+│   ├── configs
+│   ├── components
+│   ├── defs
+│   ├── interfaces
+│   ├── main
+│   ├── protocols
+│   ├── tests
+│   └── tools
+└── frontends
+    ├── android_app
+    ├── browser_extensions
+    ├── ios_app
+    └── web_application
+```
 
-- [caliopen.base](https://github.com/CaliOpen/caliopen.base)
-    abstract storage and core classes to be used by all components interacting with data.
-    contains also classes for configuration, connection management, common to all components.
+## Code organization for the backend
 
-- [caliopen.base.user](https://github.com/CaliOpen/caliopen.base.user)
-    models and related core classes for user and contact management (an user is also a contact)
+#### `main` directory
+The main application goes here. This is the entry point for the platform. From here, all relevant programs, servers and daemons are spawned, and core services/APIs are started.  
+For now, there are 2 python packages : `main/py.main` and `main/py.storage`.  
 
-- [caliopen.base.message](https://github.com/CaliOpen/caliopen.base.message)
-    models and related core classes for messages and threads management
+To startup the Caliopen platform, run the command `main/startup` 
+#### `interfaces` directory
+Public APIs consumed by frontends and clients applications over HTTP/HTTP2.  
+Examples : REST server, gRPC server…  
+For now, there is a REST python server (pyramid) into `interfaces/REST/py.server`
+#### `brokers` directory
+Brokers are program modules that offer services to parse/unparse and/or unmarshall/marshall objects between the formal external protocol of the sender and the formal internal protocol of Caliopen.  
+Examples : email broker, sms broker, vcard broker…
+#### `protocols` directory
+Program modules that implement standard protocols to connect *Brokers* to external tiers.  
+Examples : SMTP, XMPP…
+#### `components` directory
+Software components that add features to Caliopen by exposing services or procedures directly to main processes.  
+Each component can be enhanced thanks to a plugin architecture, as long as the plugin don't break the component's contract.  
+Some components could be distributed outside Caliopen as standalone packages.  
+Examples : parsers, messages qualifiers (PI computing, importance computing), keys manager, DNS…
+#### `configs` directory
+Configuration files for every platform components.
+#### `defs` directory (ie definitions)
+Interfaces, objects and methods definitions.  
+One finds here the « Single Source of Truth » to work with Caliopen's inner world.  
+Examples : databases models, protobuf files, python packages for base classes, Go struct definitions…
+#### `agents` directory
+Programs that run on-demand tasks and cron-jobs for main process and/or offer on-demand services to end-users.  
+Example : credentials manager, notifier…
+#### `tools` directory
+Standalone programs to manage the backend and the databases outside the standard interfaces.  
+Examples : caliopen CLI to import mailboxes…
+#### `tests` directory
+Test suits go there.
 
-### Protocol oriented packages
+## Code organization for the frontends
 
-- [caliopen.smtp](https://github.com/CaliOpen/caliopen.smtp)
-    Package to deliver a SMTP message into caliopen. Use at this time a LMTP server to act as MDA
-
-- [caliopen.api.base](https://github.com/CaliOpen/caliopen.api.base)
-    Base package for all Caliopen REST Api ones
-
-- [caliopen.api.user](https://github.com/CaliOpen/caliopen.api.user)
-    REST Api to manage users and contacts in a Caliopen instance
-
-- [caliopen.api.message](https://github.com/CaliOpen/caliopen.api.message)
-    REST Api to manage messages and thread in a Caliopen instance
-
-- [caliopen.web](https://github.com/CaliOpen/caliopen.web)
-    HTTP server with configured REST Api support. Will be deprecated and host only REST API
-
-### Others packages
-
-- [caliopen.cli](https://github.com/CaliOpen/caliopen.cli)
-    CLI utility for caliopen management tasks (mainly development ones at this time)
+#### `web_appliaction` directory
+All the code needed to render and to distribute the User Interface that runs into the browser. For now, it is a *Node/Express/React* application.
+#### `ios_app` directory
+User Interface application for iOS. (to be implemented)
+#### `android_app` directory
+User Interface application for android devices. (to be implemented)

--- a/index.md
+++ b/index.md
@@ -25,13 +25,25 @@ To contribute to a CaliOpen project, you MUST follow the
 ## Getting Started
 
 The development entrypoint is [CaliOpen
-dev](https://github.com/CaliOpen/caliopen-dev) repository.
+dev](https://github.com/CaliOpen/CaliOpen) repository.
 
 The bug tracker is available in [CaliOpen/Caliopen](https://github.com/CaliOpen/Caliopen/issues).
 
 ### Requirements
 
-* [Docker](https://docker.com/)
-* [Docker compose](https://docs.docker.com/compose/) ex fig
+* [Virtualbox](https://virtualbox.org)
+* [Vagrant](https://vagrantup.com)
 
-Once you have docker you can follow a [simple installation process](https://github.com/CaliOpen/caliopen-dev#caliopen-development-environment-and-toolbelt) to run a development or staging environment.
+Once you have vagrant and virtualbox installed, you can launch an development platform
+issuing theses commands:
+
+```
+cd devtools
+vagrant up
+```
+
+Are installed in this vm:
+
+- Cassandra, Elasticsearch, Redis storage services run in this VM
+- a CaliOpen LMTP server listen on port 4025 for mail delivery
+- a CaliOpen ReSt API server listen on port 6543


### PR DESCRIPTION
- Remove link to caliopen-dev repository
- Update code architecture page to new repository (it's a duplicate, we will address that when having a more structured doc in mono repository)